### PR TITLE
Want a postbuild for layout

### DIFF
--- a/src/Reflex/Vty/Widget/Layout.hs
+++ b/src/Reflex/Vty/Widget/Layout.hs
@@ -78,6 +78,7 @@ newtype Layout t m a = Layout
     , MonadReflexCreateTrigger t
     , HasDisplaySize t
     , MonadNodeId
+    , PostBuild t
     )
 
 instance MonadTrans (Layout t) where


### PR DESCRIPTION
Was there a reason that Layout didn't have a postbuild instance? 

I needed it to use listWithKey in a layout monad. Probably doing it wrong though. :)

https://github.com/benkolera/reflex-vty-play/blob/1c856f12ec58a630d42c0a897f9614d23fa3c416/watchphone.hs#L91