### PR TITLE
Add titled box widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for reflex-vty
 
+## 0.1.3.1
+* Add `boxTitle`: a box with a title
+* Update the text editing example to use `boxTitle`
+
 ## 0.1.3.0
 * Add `mouseScroll` to capture scroll wheel events
 * Add `scrollableText`: a text display widget that can be scrolled using the mouse or keyboard

--- a/src-bin/example.hs
+++ b/src-bin/example.hs
@@ -97,7 +97,8 @@ testBoxes = do
           { _textInputConfig_initialValue =
             "This box is a text input. The box below responds to mouse drag inputs. You can also drag the separator between the boxes to resize them."
           }
-        textBox = boxStatic roundedBoxStyle $ multilineTextInput cfg
+        textBox = boxTitle (pure roundedBoxStyle) "Text Edit" $
+          multilineTextInput cfg
         dragBox = boxStatic roundedBoxStyle dragTest
     in splitVDrag (hRule doubleBoxStyle) textBox dragBox
   return ()


### PR DESCRIPTION
Brick supports boxes with titles, why shouldn't reflex-vty? With this change, a more general widget `boxTitle` is implemented as a modification of `box`'s old implementation, whereas `box` itself is now a `boxTitle` with an empty title. However, the title is purely textual, in contrast with brick's, where titles can be any widgets (should it be like that?).

The text editing widget in examples is also updated to demonstrate the feature.