### PR TITLE
Data.Text.Zipper charWidth improvements and fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,10 @@
 # Revision history for reflex-vty
 
-## 0.1.4.1
+## Unreleased
+* Remove text-icu dependency and switch to `wcwidth` from vty package to compute character width in `Data.Text.Zipper`.
+* `goToDisplayLinePosition` in `Data.Text.Zipper` correctly accounts for character width now.
 
+## 0.1.4.1
 * Migrate to new dependent-sum / dependent-map (after the "some" package split)
 
 ## 0.1.4.0

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -47,7 +47,7 @@ library
     ref-tf >= 0.4.0 && < 0.5,
     reflex >= 0.7.2 && < 0.8,
     time >= 1.8.0 && < 1.10,
-    vty >= 5.21 && < 5.29
+    vty >= 5.28 && < 5.29
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -40,7 +40,6 @@ library
     data-default >= 0.7.1 && < 0.8,
     dependent-map >= 0.4 && < 0.5,
     text >= 1.2.3 && < 1.3,
-    text-icu >= 0.7 && < 0.8,
     dependent-sum >= 0.7 && < 0.8,
     exception-transformers >= 0.4.0 && < 0.5,
     primitive >= 0.6.3 && < 0.8,

--- a/src/Data/Text/Zipper.hs
+++ b/src/Data/Text/Zipper.hs
@@ -413,8 +413,8 @@ widthI (Stream next s0 _len) = loop_length 0 s0
                            Yield c s' -> loop_length (z + charWidth c) s'
 {-# INLINE[0] widthI #-}
 
--- | Compute the width of a stream of characters, taking into account
--- fullwidth unicode forms.
+-- | Compute the logical index position of a stream of characters from a visual
+-- position taking into account fullwidth unicode forms.
 charIndexAt :: Int -> Stream Char -> Int
 charIndexAt pos (Stream next s0 _len) = loop_length 0 0 s0
     where


### PR DESCRIPTION

Switch `charWidth` to use `wcwidth` from `Graphics.Text.Width` in vty:
- since reflex-vty runs on vty, it should use the same char width function as vty. Note that ICU package does not report the correct char width for all unicode chars. 

Change `goToDisplayLinePosition` to include `charWidth`: 
previously `goToDisplayLinePosition` would count each character as having width 1 causing cursor position to be incorrect when wide characters were present

Testing: pasted wide characters in "Text Editor" example and intermixed with normal sized characters. Move cursor around including end of line and observed cursor position is as expected.
