### PR TITLE
Improve Layout

### DIFF
--- a/src-bin/example.hs
+++ b/src-bin/example.hs
@@ -26,6 +26,38 @@ import Reflex.Network
 import Reflex.Class.Switchable
 import Reflex.Vty
 
+easyExample :: IO ()
+easyExample = mainWidget $ do
+  beginLayoutD $ col $ do
+    (a1,b1,c1) <- fixedD 3 $ row $ do
+      a <- fixed 15 $ textButtonStatic def "POTATO"
+      b <- fixed 15 $ textButtonStatic def "TOMATO"
+      --c <- stretch $ textButtonStatic def "EGGPLANT"
+      c <- stretchD $ row $ do
+        stretch $ textButtonStatic def "A"
+        stretch $ textButtonStatic def "B"
+        stretch $ textButtonStatic def "C"
+      return (a,b,c)
+    (a2,b2,c2) <- fixedD 3 $ row $ do
+      a <- stretch $ textButtonStatic def "CHEESE"
+      b <- stretch $ textButtonStatic def "BEES"
+      c <- stretch $ textButtonStatic def "ARROW IN MY KNEE"
+      stretch $ textButtonStatic def "boop"
+      stretch $ textButtonStatic def "doop"
+      stretch $ textButtonStatic def "goop"
+      return (a,b,c)
+    (a3,b3,c3) <- fixedD 3 $ row $ do
+      a <- stretch $ textButtonStatic def "TIME"
+      b <- stretch $ textButtonStatic def "RHYME"
+      c <- stretch $ textButtonStatic def "A BIG CRIME"
+      return (a,b,c)
+    return ()
+  inp <- input
+  return $ fforMaybe inp $ \case
+    V.EvKey (V.KChar 'c') [V.MCtrl] -> Just ()
+    _ -> Nothing
+
+
 data Example = Example_TextEditor
              | Example_Todo
              | Example_ScrollableTextDisplay
@@ -61,7 +93,7 @@ main = mainWidget $ do
   return $ fforMaybe inp $ \case
     V.EvKey (V.KChar 'c') [V.MCtrl] -> Just ()
     _ -> Nothing
- 
+
 taskList
   :: (Reflex t, MonadHold t m, MonadFix m, Adjustable t m, NotReady t m, PostBuild t m, MonadNodeId m)
   => VtyWidget t m ()
@@ -153,7 +185,7 @@ todo t0 = do
           checkboxRegion = DynRegion 0 0 checkboxWidth 1
           labelHeight = _textInput_lines ti
           labelWidth = w - 1 - checkboxWidth
-          labelLeft = checkboxWidth + 1 
+          labelLeft = checkboxWidth + 1
           labelTop = constDyn 0
           labelRegion = DynRegion labelLeft labelTop labelWidth labelHeight
       value <- pane checkboxRegion (pure True) $ checkbox def $ _todo_done t0

--- a/src-bin/example.hs
+++ b/src-bin/example.hs
@@ -230,9 +230,9 @@ todos todos0 newTodo = do
   rec tabNav <- tabNavigation
       let insertNav = 1 <$ insert
           navEv = leftmost [tabNav, insertNav]
-          focusEv = fmap (\(mcur, shift) -> maybe (Just 0) (\cur -> Just $ (shift + cur) `mod` _layoutReturnData_children) mcur) (attach (current _layoutReturnData_focus) navEv)
+          focusEv = layoutFocusEvFromNavigation navEv lrd
           tileCfg = def { _tileConfig_constraint = pure $ Constraint_Fixed 1}
-      LayoutReturnData {..} <- flip runIsLayoutVtyWidget focusEv $ runLayoutL (pure Orientation_Column) (Just 0) $
+      lrd@LayoutReturnData {..} <- flip runIsLayoutVtyWidget focusEv $ runLayoutL (pure Orientation_Column) (Just 0) $
         listHoldWithKey todosMap0 updates $ \k t -> tile tileCfg $ do
           let sel = select selectOnDelete $ Const2 k
           click <- void <$> mouseDown V.BLeft

--- a/src-bin/example.hs
+++ b/src-bin/example.hs
@@ -230,7 +230,7 @@ todos todos0 newTodo = do
   rec tabNav <- tabNavigation
       let insertNav = 1 <$ insert
           navEv = leftmost [tabNav, insertNav]
-          focusEv = layoutFocusEvFromNavigation navEv lrd
+          focusEv = layoutFocusEvFromNavigation navEv never lrd
           tileCfg = def { _tileConfig_constraint = pure $ Constraint_Fixed 1}
       lrd@LayoutReturnData {..} <- flip runIsLayoutVtyWidget focusEv $ runLayoutL (pure Orientation_Column) (Just 0) $
         listHoldWithKey todosMap0 updates $ \k t -> tile tileCfg $ do

--- a/src/Reflex/Vty/Widget/Layout.hs
+++ b/src/Reflex/Vty/Widget/Layout.hs
@@ -8,12 +8,12 @@ Description: Monad transformer and tools for arranging widgets and building scre
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE RecursiveDo                #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE TypeApplications       #-}
-{-# LANGUAGE RankNTypes       #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
 
 
 module Reflex.Vty.Widget.Layout
@@ -50,7 +50,7 @@ import           Data.Bimap             (Bimap)
 import qualified Data.Bimap             as Bimap
 import           Data.Default           (Default (..))
 import qualified Data.Dependent.Map     as DMap
-import Data.Dependent.Sum (DSum((:=>)))
+import           Data.Dependent.Sum     (DSum ((:=>)))
 import           Data.Functor.Misc
 import           Data.Map               (Map)
 import qualified Data.Map               as Map
@@ -68,20 +68,20 @@ import           Reflex.Vty.Widget
 
 -- | The main-axis orientation of a 'Layout' widget
 data Orientation = Orientation_Column
-                 | Orientation_Row
-  deriving (Show, Read, Eq, Ord)
+    | Orientation_Row
+    deriving (Show, Read, Eq, Ord)
 
 data LayoutSegment = LayoutSegment
-  { _layoutSegment_offset :: Int
-  , _layoutSegment_size   :: Int
-  }
+    { _layoutSegment_offset :: Int
+    , _layoutSegment_size   :: Int
+    }
 
 data LayoutCtx t = LayoutCtx
-  { _layoutCtx_regions            :: Dynamic t (Map NodeId LayoutSegment)
-  , _layoutCtx_focusSelfDemux     :: Demux t (Maybe NodeId)
-  , _layoutCtx_orientation        :: Dynamic t Orientation
-  , _layoutCtx_focusChildSelector :: EventSelector t (Const2 NodeId (Maybe Int))
-  }
+    { _layoutCtx_regions :: Dynamic t (Map NodeId LayoutSegment)
+    , _layoutCtx_focusSelfDemux :: Demux t (Maybe NodeId)
+    , _layoutCtx_orientation :: Dynamic t Orientation
+    , _layoutCtx_focusChildSelector :: EventSelector t (Const2 NodeId (Maybe Int))
+    }
 
 
 -- | The Layout monad transformer keeps track of the configuration (e.g., 'Orientation') and
@@ -138,7 +138,7 @@ fanFocusEv :: (Reflex t) => Behavior t (Maybe (NodeId, Int)) -> Event t (Maybe (
 fanFocusEv focussed focusReqIx = fan $ attachWith attachfn focussed focusReqIx where
   attachfn mkv0 mkv1 = case mkv1 of
     Nothing -> case mkv0 of
-      Nothing      -> DMap.empty
+      Nothing     -> DMap.empty
       Just (k0,_) -> DMap.fromList [Const2 k0 :=> Identity Nothing]
     Just (k1,v1) -> case mkv0 of
       Nothing -> DMap.fromList [Const2 k1 :=> Identity (Just v1)]
@@ -307,11 +307,11 @@ tile = tile_
 
 -- | Configuration options for and constraints on 'tile_'
 data TileConfig t = TileConfig
-  { _tileConfig_constraint :: Dynamic t Constraint
+    { _tileConfig_constraint :: Dynamic t Constraint
     -- ^ 'Constraint' on the tile_'s size
-  , _tile_Config_focusable  :: Dynamic t Bool
+    , _tile_Config_focusable :: Dynamic t Bool
     -- ^ Whether the tile_ is focusable
-  }
+    }
 
 instance Reflex t => Default (TileConfig t) where
   def = TileConfig (pure $ Constraint_Min 0) (pure True)
@@ -430,8 +430,8 @@ askOrientation = Layout $ asks _layoutCtx_orientation
 
 -- | Datatype representing constraints on a widget's size along the main axis (see 'Orientation')
 data Constraint = Constraint_Fixed Int
-                | Constraint_Min Int
-  deriving (Show, Read, Eq, Ord)
+    | Constraint_Min Int
+    deriving (Show, Read, Eq, Ord)
 
 -- | Compute the size of each widget "@k@" based on the total set of 'Constraint's
 computeSizes
@@ -460,7 +460,8 @@ computeEdges = fst . Map.foldlWithKey' (\(m, offset) k (a, sz) ->
 -- TODO FINISH
 -- but it's weird cuz a leaf node won't know it's PosDim until combined with a Region...
 -- | Dynamic sizing information on a layout hierarchy (intended for testing)
-data LayoutDebugTree t = LayoutDebugTree_Branch [LayoutDebugTree t] | LayoutDebugTree_Leaf
+data LayoutDebugTree t = LayoutDebugTree_Branch [LayoutDebugTree t]
+    | LayoutDebugTree_Leaf
 
 emptyLayoutDebugTree :: LayoutDebugTree t
 emptyLayoutDebugTree = LayoutDebugTree_Leaf
@@ -471,12 +472,12 @@ class IsLayoutReturn t b a where
   getLayoutFocussedDyn :: b -> Dynamic t (Maybe Int)
   getLayoutTree :: b -> LayoutDebugTree t
 
-data LayoutReturnData t a = LayoutReturnData {
-    _layoutReturnData_tree :: LayoutDebugTree t
-    , _layoutReturnData_focus :: Dynamic t (Maybe Int)
+data LayoutReturnData t a = LayoutReturnData
+    { _layoutReturnData_tree     :: LayoutDebugTree t
+    , _layoutReturnData_focus    :: Dynamic t (Maybe Int)
     , _layoutReturnData_children :: Int
-    , _layoutReturnData_value :: a
-  }
+    , _layoutReturnData_value    :: a
+    }
 
 instance IsLayoutReturn t (LayoutReturnData t a) a where
   getLayoutResult lrd = _layoutReturnData_value lrd

--- a/src/Reflex/Vty/Widget/Layout.hs
+++ b/src/Reflex/Vty/Widget/Layout.hs
@@ -1,15 +1,15 @@
-{-|
-Module: Reflex.Vty.Widget.Layout
-Description: Monad transformer and tools for arranging widgets and building screen layouts
--}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes        #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecursiveDo #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE RecursiveDo                #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
-module Reflex.Vty.Widget.Layout
+
+module Potato.Reflex.Vty.Widget.Layout2
   (  Orientation(..)
   , Constraint(..)
   , Layout
@@ -17,29 +17,48 @@ module Reflex.Vty.Widget.Layout
   , TileConfig(..)
   , tile
   , fixed
+  , fixedD
   , stretch
+  , stretchD
   , col
   , row
+  , dummy
+  , beginLayout
+  , beginLayoutD
   , tabNavigation
   , askOrientation
   ) where
 
-import Control.Monad.NodeId (NodeId, MonadNodeId(..))
-import Control.Monad.Reader
-import Data.Bimap (Bimap)
-import qualified Data.Bimap as Bimap
-import Data.Default (Default(..))
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Maybe (fromMaybe)
-import Data.Monoid hiding (First(..))
-import Data.Ratio ((%))
-import Data.Semigroup (First(..))
-import qualified Graphics.Vty as V
+import           Prelude
 
-import Reflex
-import Reflex.Host.Class (MonadReflexCreateTrigger)
-import Reflex.Vty.Widget
+import qualified Relude                 as R
+
+import           Control.Monad.Identity (Identity (..))
+import           Control.Monad.NodeId   (MonadNodeId (..), NodeId (..))
+import           Control.Monad.Reader
+import           Data.Bimap             (Bimap)
+import qualified Data.Bimap             as Bimap
+import           Data.Default           (Default (..))
+import           Data.Dependent.Map     (DMap, DSum ((:=>)))
+import qualified Data.Dependent.Map     as DMap
+import           Data.Functor.Misc
+import           Data.Map               (Map)
+import qualified Data.Map               as Map
+import qualified Data.Map.Internal      as Map (Map (Bin, Tip))
+import           Data.Maybe             (fromMaybe, isJust)
+import           Data.Monoid            hiding (First (..))
+import           Data.Ratio             ((%))
+import           Data.Semigroup         (First (..))
+import           Data.Traversable       (mapAccumL)
+import           Data.Tuple.Extra
+import qualified Graphics.Vty           as V
+import           Unsafe.Coerce
+
+import           Reflex
+import           Reflex.Host.Class      (MonadReflexCreateTrigger)
+import           Reflex.Vty.Widget
+
+import           Control.Exception      (assert)
 
 -- | The main-axis orientation of a 'Layout' widget
 data Orientation = Orientation_Column
@@ -48,21 +67,23 @@ data Orientation = Orientation_Column
 
 data LayoutSegment = LayoutSegment
   { _layoutSegment_offset :: Int
-  , _layoutSegment_size :: Int
+  , _layoutSegment_size   :: Int
   }
 
 data LayoutCtx t = LayoutCtx
-  { _layoutCtx_regions :: Dynamic t (Map NodeId LayoutSegment)
-  , _layoutCtx_focusDemux :: Demux t (Maybe NodeId)
-  , _layoutCtx_orientation :: Dynamic t Orientation
+  { _layoutCtx_regions            :: Dynamic t (Map NodeId LayoutSegment)
+  , _layoutCtx_focusSelfDemux     :: Demux t (Maybe NodeId)
+  , _layoutCtx_orientation        :: Dynamic t Orientation
+  , _layoutCtx_focusChildSelector :: EventSelector t (Const2 NodeId (Maybe Int))
   }
+
 
 -- | The Layout monad transformer keeps track of the configuration (e.g., 'Orientation') and
 -- 'Constraint's of its child widgets, apportions vty real estate to each, and acts as a
 -- switchboard for focus requests. See 'tile' and 'runLayout'.
 newtype Layout t m a = Layout
-  { unLayout :: EventWriterT t (First NodeId)
-      (DynamicWriterT t (Endo [(NodeId, (Bool, Constraint))])
+  { unLayout :: EventWriterT t (First (NodeId, Int))
+      (DynamicWriterT t (Endo [(NodeId, (Bool, Constraint), LayoutDebugTree t, Int)])
         (ReaderT (LayoutCtx t)
           (VtyWidget t m))) a
   } deriving
@@ -90,70 +111,147 @@ instance (Adjustable t m, MonadFix m, MonadHold t m) => Adjustable t (Layout t m
   traverseDMapWithKeyWithAdjust f m e = Layout $ traverseDMapWithKeyWithAdjust (\k v -> unLayout $ f k v) m e
   traverseDMapWithKeyWithAdjustWithMove f m e = Layout $ traverseDMapWithKeyWithAdjustWithMove (\k v -> unLayout $ f k v) m e
 
+
+findNearestFloor_ :: (Ord k) => k -> (k, a) -> (k, a) -> Map k a -> Maybe (k, a)
+findNearestFloor_ target leftmost parent Map.Tip = if target < fst leftmost
+  then Nothing -- error $ "Map.findNearestFloorSure: map has no element <= " <> show target
+  else if target < fst parent
+    then Just leftmost
+    else Just parent
+findNearestFloor_ target leftmost _ (Map.Bin _ k a l r) = if target == k
+  then Just (k, a)
+  else if target < k
+    then findNearestFloor_ target leftmost (k, a) l
+    else findNearestFloor_ target (k, a) (k, a) r
+
+findNearestFloor :: (Ord k) => k -> Map k a -> Maybe (k,a)
+findNearestFloor _ Map.Tip = Nothing
+-- TODO I don't think we need to do findMin here, just pass in (k,x) as a placeholder value
+findNearestFloor target m@(Map.Bin _ k x _ _) = findNearestFloor_ target (Map.findMin m) (k, x) m
+
+
+
+fanFocusEv :: (Reflex t) => Behavior t (Maybe (NodeId, Int)) -> Event t (Maybe (NodeId, Int)) -> EventSelector t (Const2 NodeId (Maybe Int))
+fanFocusEv focussed focusReqIx = fan $ attachWith attachfn focussed focusReqIx where
+  attachfn mkv0 mkv1 = case mkv1 of
+    Nothing -> case mkv0 of
+      Nothing      -> DMap.empty
+      Just (k0,v0) -> DMap.fromList [Const2 k0 :=> Identity Nothing]
+    Just (k1,v1) -> case mkv0 of
+      Nothing -> DMap.fromList [Const2 k1 :=> Identity (Just v1)]
+      Just (k0,v0) | k0 == k1 && v0 == v1 -> DMap.empty
+      Just (k0,v0) | k0 == k1 -> DMap.fromList [Const2 k1 :=> Identity (Just v1)]
+      Just (k0,v0) -> DMap.fromList [Const2 k0 :=> Identity Nothing,
+                          Const2 k1 :=> Identity (Just v1)]
+
 -- | Run a 'Layout' action
-runLayout
-  :: (MonadFix m, MonadHold t m, PostBuild t m, Monad m, MonadNodeId m)
+runLayoutD
+  :: forall t m a. (Reflex t, MonadFix m, MonadHold t m, Monad m, MonadNodeId m)
   => Dynamic t Orientation -- ^ The main-axis 'Orientation' of this 'Layout'
-  -> Int -- ^ The positional index of the initially focused tile
-  -> Event t Int -- ^ An event that shifts focus by a given number of tiles
+  -> Maybe Int -- ^ The positional index of the initially focused tile
   -> Layout t m a -- ^ The 'Layout' widget
-  -> VtyWidget t m a
-runLayout ddir focus0 focusShift (Layout child) = do
+  -> LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+runLayoutD ddir mfocus0 (Layout child) = LayoutVtyWidget . ReaderT $ \focusReqIx -> mdo
   dw <- displayWidth
   dh <- displayHeight
   let main = ffor3 ddir dw dh $ \d w h -> case d of
         Orientation_Column -> h
-        Orientation_Row -> w
-  pb <- getPostBuild
-  rec ((a, focusReq), queriesEndo) <- runReaderT (runDynamicWriterT $ runEventWriterT child) $ LayoutCtx solutionMap focusDemux ddir
-      let queries = flip appEndo [] <$> queriesEndo
-          solution = ffor2 main queries $ \sz qs -> Map.fromList
-            . Map.elems
-            . computeEdges
-            . computeSizes sz
-            . fmap (fmap snd)
-            . Map.fromList
-            . zip [0::Integer ..]
-            $ qs
-          solutionMap = ffor solution $ \ss -> ffor ss $ \(offset, sz) -> LayoutSegment
-            { _layoutSegment_offset = offset
-            , _layoutSegment_size = sz
-            }
-          focusable = fmap (Bimap.fromList . zip [0..]) $
-            ffor queries $ \qs -> fforMaybe qs $ \(nodeId, (f, _)) ->
-              if f then Just nodeId else Nothing
-          adjustFocus
-            :: (Bimap Int NodeId, (Int, Maybe NodeId))
-            -> Either Int NodeId
-            -> (Int, Maybe NodeId)
-          adjustFocus (fm, (cur, _)) (Left shift) =
-            let ix = (cur + shift) `mod` (max 1 $ Bimap.size fm)
-            in (ix, Bimap.lookup ix fm)
-          adjustFocus (fm, (cur, _)) (Right goto) =
-            let ix = fromMaybe cur $ Bimap.lookupR goto fm
-            in (ix, Just goto)
-          focusChange = attachWith
-            adjustFocus
-            (current $ (,) <$> focusable <*> focussed)
-            $ leftmost [Left <$> focusShift, Left 0 <$ pb, Right . getFirst <$> focusReq]
-      -- A pair (Int, Maybe NodeId) which represents the index
-      -- that we're trying to focus, and the node that actually gets
-      -- focused (at that index) if it exists
-      focussed <- holdDyn (focus0, Nothing) focusChange
-      let focusDemux = demux $ snd <$> focussed
-  return a
+        Orientation_Row    -> w
+  ((a, focusReq), queriesEndo) <- runReaderT (runDynamicWriterT $ runEventWriterT child) $ LayoutCtx solutionMap focusDemux ddir focusChildSelector
+  let queries = flip appEndo [] <$> queriesEndo
+      solution = ffor2 main queries $ \sz qs -> Map.fromList
+        . Map.elems
+        . computeEdges
+        . computeSizes sz
+        . fmap (\(nodeid,(_,constraint),_,_) -> (nodeid,constraint))
+        . Map.fromList
+        . zip [0::Integer ..]
+        $ qs
+      solutionMap = ffor solution $ \ss -> ffor ss $ \(offset, sz) -> LayoutSegment
+        { _layoutSegment_offset = offset
+        , _layoutSegment_size = sz
+        }
+
+
+      focusableMapAccumFn acc (nodeId, (_, _), _, nKiddos) = (nextAcc, value) where
+        nextAcc = acc + nKiddos
+        value = (acc, nodeId)
+      focusable' = fmap (Bimap.fromList . snd . mapAccumL focusableMapAccumFn 0) $
+        ffor queries $ \qs -> fforMaybe qs $ \n@(_, (f, _), _, nc) ->
+          if f && nc > 0 then Just n else Nothing
+      focusable = focusable'
+
+      -- ix is focus in self index space
+      -- fst of return value is child node id to focus
+      -- snd of return value is focus in child's index space
+      findChildFocus :: Bimap Int NodeId -> Int -> Maybe (NodeId, Int)
+      findChildFocus fm ix = findNearestFloor ix (Bimap.toMap fm) >>= \(ixl, t) -> Just (t, ix-ixl)
+
+      adjustFocus
+        :: (Bimap Int NodeId)
+        -> Either Int (NodeId, Int) -- left is self index, right is (child id, child index)
+        -> Maybe (Int, (NodeId, Int)) -- fst is self index, snd is (child id, child index)
+      adjustFocus fm (Left ix) = do
+        x <- findChildFocus fm ix
+        return (ix, x)
+      adjustFocus fm (Right (goto, ixrel)) = do
+        ix <- Bimap.lookupR goto fm
+        return (ix+ixrel, (goto, ixrel))
+
+      focusChange = attachWith adjustFocus (current focusable)
+        -- TODO handle Nothing case in both places (so that event produces Nothing in this case)
+        $ leftmost [ fmap Right . fmap getFirst $ focusReq, Left <$> (fmapMaybe id focusReqIx)]
+
+
+  fm0 <- sample . current $ focusable
+  totalKiddos <- sample . current $ fmap (sum . fmap (\(_,_,_,k) -> k)) queries
+
+  -- brief explanation of overly complicated focus tracking
+  -- focus is propogated in 2 ways
+  -- focusReq (focus from bottom up)
+  -- focusReqIx (focus from top down)
+  -- focussed tracks the focus state
+  -- focusDemux is used to pass the 'pane's of immediate children
+
+  -- fst is index we want to focus in self index space, snd is node id we want to focus
+  focussed :: Dynamic t (Maybe (Int, (NodeId, Int))) <- holdDyn initialFocus (focusChange)
+  let
+    initialFocus :: Maybe (Int, (NodeId, Int)) = do
+      f0 <- mfocus0
+      cf0 <- findChildFocus fm0 f0
+      return (f0, cf0)
+
+    focussedForDemux = fmap (fmap (fst . snd)) focussed
+    focusDemux :: Demux t (Maybe NodeId) = demux focussedForDemux
+
+    focusReqWithNodeId :: Event t (Maybe (NodeId, Int))
+    focusReqWithNodeId = attachWith (\fm mix -> mix >>= \ix -> findChildFocus fm ix) (current focusable) (focusReqIx)
+    focusChildSelector = fanFocusEv (current $ fmap (fmap snd) focussed) (focusReqWithNodeId)
+
+  return (emptyLayoutDebugTree, (fmap (fmap fst)) focussed, totalKiddos, a)
+
+-- | Run a 'Layout' action
+runLayout
+  :: (MonadFix m, MonadHold t m, PostBuild t m, Monad m, MonadNodeId m)
+  => Dynamic t Orientation -- ^ The main-axis 'Orientation' of this 'Layout'
+  -> Maybe Int -- ^ The positional index of the initially focused tile
+  -> Layout t m a -- ^ The 'Layout' widget
+  -> LayoutVtyWidget t m a
+runLayout ddir mfocus0 layout = fmap (\(_,_,_,a)->a) $ runLayoutD ddir mfocus0 layout
 
 -- | Tiles are the basic building blocks of 'Layout' widgets. Each tile has a constraint
 -- on its size and ability to grow and on whether it can be focused. It also allows its child
 -- widget to request focus.
 tile
-  :: (Reflex t, Monad m, MonadNodeId m)
+  :: forall t b widget x m a. (Reflex t, IsLayoutReturn t b a, IsLayoutVtyWidget widget t m, Monad m, MonadFix m, MonadNodeId m)
   => TileConfig t -- ^ The tile's configuration
-  -> VtyWidget t m (Event t x, a) -- ^ A child widget. The 'Event' that it returns is used to request that it be focused.
+  -> widget t m (Event t x, b) -- ^ A child widget. The 'Event' that it returns is used to request that it be focused.
   -> Layout t m a
-tile (TileConfig con focusable) child = do
+tile (TileConfig con focusable) child = mdo
   nodeId <- getNextNodeId
-  Layout $ tellDyn $ ffor2 con focusable $ \c f -> Endo ((nodeId, (f, c)):)
+  -- by calling getLayoutTree/getLayoutNumChildren here, we store the children's layout info inside the DynamicWriter
+  -- runLayoutD will extract this info later
+  Layout $ tellDyn $ ffor2 con focusable $ \c f -> Endo ((nodeId, (f, c), getLayoutTree @t @b @a b, nKiddos):)
   seg <- Layout $ asks $
     fmap (Map.findWithDefault (LayoutSegment 0 0) nodeId) . _layoutCtx_regions
   dw <- displayWidth
@@ -176,58 +274,92 @@ tile (TileConfig con focusable) child = do
             Orientation_Column -> _layoutSegment_size s
             Orientation_Row -> c
         }
-  focussed <- Layout $ asks _layoutCtx_focusDemux
-  (focusReq, a) <- Layout $ lift $ lift $ lift $
-    pane reg (demuxed focussed $ Just nodeId) $ child
-  Layout $ tellEvent $ First nodeId <$ focusReq
-  return a
+  let nKiddos = getLayoutNumChildren @t @b @a b
+
+  focusChildSelector <- Layout $ asks _layoutCtx_focusChildSelector
+  let focusChildEv = select focusChildSelector (Const2 nodeId)
+  focussed <- Layout $ asks _layoutCtx_focusSelfDemux
+  (focusReq, b) <- Layout $ lift $ lift $ lift $
+    pane reg (demuxed focussed $ Just nodeId) $ runIsLayoutVtyWidget child (focusChildEv)
+  Layout $ tellEvent $ if nKiddos > 0
+    then fmap (First . swap) $ attachPromptlyDyn (fmap (fromMaybe 0) $ getLayoutFocussedDyn @t @b @a b) (nodeId <$ focusReq)
+    else never
+  return $ getLayoutResult @t b
+
 
 -- | Configuration options for and constraints on 'tile'
 data TileConfig t = TileConfig
   { _tileConfig_constraint :: Dynamic t Constraint
     -- ^ 'Constraint' on the tile's size
-  , _tileConfig_focusable :: Dynamic t Bool
+  , _tileConfig_focusable  :: Dynamic t Bool
     -- ^ Whether the tile is focusable
   }
+
 
 instance Reflex t => Default (TileConfig t) where
   def = TileConfig (pure $ Constraint_Min 0) (pure True)
 
 -- | A 'tile' of a fixed size that is focusable and gains focus on click
-fixed
-  :: (Reflex t, Monad m, MonadNodeId m)
+fixed'
+  :: (Reflex t, IsLayoutReturn t b a, IsLayoutVtyWidget widget t m, Monad m, MonadFix m, MonadNodeId m)
   => Dynamic t Int
-  -> VtyWidget t m a
+  -> widget t m b
   -> Layout t m a
-fixed sz = tile (def { _tileConfig_constraint =  Constraint_Fixed <$> sz }) . clickable
+fixed' sz = tile (def { _tileConfig_constraint =  Constraint_Fixed <$> sz }) . clickable
+
+fixedD
+  :: (Reflex t, Monad m, MonadFix m, MonadNodeId m)
+  => Dynamic t Int
+  -> LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+  -> Layout t m a
+fixedD = fixed'
+
+fixed
+  :: (Reflex t, IsLayoutVtyWidget widget t m, Monad m, MonadFix m, MonadNodeId m)
+  => Dynamic t Int
+  -> widget t m a
+  -> Layout t m a
+fixed = fixed'
 
 -- | A 'tile' that can stretch (i.e., has no fixed size) and has a minimum size of 0.
 -- This tile is focusable and gains focus on click.
-stretch
-  :: (Reflex t, Monad m, MonadNodeId m)
-  => VtyWidget t m a
+stretch'
+  :: (Reflex t, IsLayoutReturn t b a, IsLayoutVtyWidget widget t m, Monad m, MonadFix m, MonadNodeId m)
+  => widget t m b
   -> Layout t m a
-stretch = tile def . clickable
+stretch' = tile def . clickable
+
+stretchD
+  :: (Reflex t, Monad m, MonadFix m, MonadNodeId m)
+  => LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+  -> Layout t m a
+stretchD = stretch'
+
+stretch
+  :: (Reflex t, IsLayoutVtyWidget widget t m, Monad m, MonadFix m, MonadNodeId m)
+  => widget t m a
+  -> Layout t m a
+stretch = stretch'
 
 -- | A version of 'runLayout' that arranges tiles in a column and uses 'tabNavigation' to
 -- change tile focus.
 col
   :: (MonadFix m, MonadHold t m, PostBuild t m, MonadNodeId m)
   => Layout t m a
-  -> VtyWidget t m a
-col child = do
-  nav <- tabNavigation
-  runLayout (pure Orientation_Column) 0 nav child
+  -> LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+col child = runLayoutD (pure Orientation_Column) (Just 0) child
 
 -- | A version of 'runLayout' that arranges tiles in a row and uses 'tabNavigation' to
 -- change tile focus.
 row
   :: (MonadFix m, MonadHold t m, PostBuild t m, MonadNodeId m)
   => Layout t m a
-  -> VtyWidget t m a
-row child = do
-  nav <- tabNavigation
-  runLayout (pure Orientation_Row) 0 nav child
+  -> LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+row child = runLayoutD (pure Orientation_Row) (Just 0) child
+
+-- | Testing placeholder DELETE
+dummy :: (Reflex t, Monad m) => LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, ())
+dummy = return (emptyLayoutDebugTree, constDyn Nothing, 0, ())
 
 -- | Produces an 'Event' that navigates forward one tile when the Tab key is pressed
 -- and backward one tile when Shift+Tab is pressed.
@@ -240,13 +372,32 @@ tabNavigation = do
 -- | Captures the click event in a 'VtyWidget' context and returns it. Useful for
 -- requesting focus when using 'tile'.
 clickable
-  :: (Reflex t, Monad m)
-  => VtyWidget t m a
-  -> VtyWidget t m (Event t (), a)
-clickable child = do
+  :: (Reflex t, IsLayoutVtyWidget widget t m, Monad m)
+  => widget t m a
+  -> LayoutVtyWidget t m (Event t (), a)
+clickable child = LayoutVtyWidget . ReaderT $ \focusEv -> do
   click <- mouseDown V.BLeft
-  a <- child
+  a <- runIsLayoutVtyWidget child focusEv
   return (() <$ click, a)
+
+beginLayoutD ::
+  forall m t a. (MonadHold t m, PostBuild t m, MonadFix m, MonadNodeId m)
+  => LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+  -> VtyWidget t m (LayoutDebugTree t, a)
+beginLayoutD child = mdo
+  -- TODO consider unfocusing if this loses focus
+  --focussed <- focus
+  tabEv <- tabNavigation
+  let focusChildEv = fmap (\(mcur, shift) -> maybe (Just 0) (\cur -> Just $ (shift + cur) `mod` totalKiddos) mcur) (attach (current indexDyn) tabEv)
+  (ldt, indexDyn, totalKiddos, a) <- runIsLayoutVtyWidget child focusChildEv
+  return (ldt, a)
+
+-- |
+beginLayout ::
+  forall m t b a. (MonadHold t m, PostBuild t m, MonadFix m, MonadNodeId m)
+  => LayoutVtyWidget t m (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a)
+  -> VtyWidget t m a
+beginLayout = fmap snd . beginLayoutD
 
 -- | Retrieve the current orientation of a 'Layout'
 askOrientation :: Monad m => Layout t m (Dynamic t Orientation)
@@ -273,13 +424,74 @@ computeSizes available constraints =
       adjustment = max 0 $ available - minTotal - szStretch * numStretch
   in snd $ Map.mapAccum (\adj (a, c) -> case c of
       Constraint_Fixed n -> (adj, (a, n))
-      Constraint_Min n -> (0, (a, n + szStretch + adj))) adjustment constraints
+      Constraint_Min n   -> (0, (a, n + szStretch + adj))) adjustment constraints
   where
     isMin (Constraint_Min _) = True
-    isMin _ = False
+    isMin _                  = False
 
 computeEdges :: (Ord k) => Map k (a, Int) -> Map k (a, (Int, Int))
 computeEdges = fst . Map.foldlWithKey' (\(m, offset) k (a, sz) ->
   (Map.insert k (a, (offset, sz)) m, sz + offset)) (Map.empty, 0)
 
 
+
+
+
+
+
+
+-- TODO should prob be (Branch [LayoutDebugTree] | Leaf PosDim
+-- but it's weird cuz a leaf node won't know it's PosDim until combined with a Region...
+data LayoutDebugTree t = LayoutDebugTree_Branch [LayoutDebugTree t] | LayoutDebugTree_Leaf
+
+emptyLayoutDebugTree :: LayoutDebugTree t
+emptyLayoutDebugTree = LayoutDebugTree_Leaf
+
+class IsLayoutReturn t b a where
+  getLayoutResult :: b -> a
+  getLayoutNumChildren :: b -> Int
+  getLayoutFocussedDyn :: b -> Dynamic t (Maybe Int)
+  getLayoutTree :: b -> LayoutDebugTree t
+
+
+instance IsLayoutReturn t (LayoutDebugTree t, Dynamic t (Maybe Int), Int, a) a where
+  getLayoutResult (_,_,_,a) = a
+  getLayoutNumChildren (_,_,d,_) = d
+  getLayoutFocussedDyn (_,d,_,_) = d
+  getLayoutTree (tree,_,_,_) = tree
+
+instance Reflex t => IsLayoutReturn t a a where
+  getLayoutResult = id
+  getLayoutNumChildren _ = 1
+  getLayoutFocussedDyn _ = constDyn Nothing
+  getLayoutTree _ = emptyLayoutDebugTree
+
+class IsLayoutVtyWidget l t (m :: * -> *) where
+  runIsLayoutVtyWidget :: l t m a -> Event t (Maybe Int) -> VtyWidget t m a
+
+newtype LayoutVtyWidget t m a = LayoutVtyWidget {
+    unLayoutVtyWidget :: ReaderT (Event t (Maybe Int)) (VtyWidget t m) a
+  } deriving
+    ( Functor
+    , Applicative
+    , Monad
+    , MonadHold t
+    , MonadSample t
+    , MonadFix
+    , TriggerEvent t
+    , PerformEvent t
+    , NotReady t
+    , MonadReflexCreateTrigger t
+    , HasDisplaySize t
+    , MonadNodeId
+    , PostBuild t
+    )
+
+instance MonadTrans (LayoutVtyWidget t) where
+  lift x = LayoutVtyWidget $ lift $ lift x
+
+instance IsLayoutVtyWidget VtyWidget t m where
+  runIsLayoutVtyWidget w _ = w
+
+instance IsLayoutVtyWidget LayoutVtyWidget t m where
+  runIsLayoutVtyWidget = runReaderT . unLayoutVtyWidget

--- a/src/Reflex/Vty/Widget/Layout.hs
+++ b/src/Reflex/Vty/Widget/Layout.hs
@@ -1,3 +1,7 @@
+{-|
+Module: Reflex.Vty.Widget.Layout
+Description: Monad transformer and tools for arranging widgets and building screen layouts
+-}
 {-# LANGUAGE AllowAmbiguousTypes        #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}


### PR DESCRIPTION
This PR is paired with [this issue](https://github.com/reflex-frp/reflex-vty/issues/37) explaining the changes.

Test cases for changes are [here](https://github.com/pdlla/potato-flow-vty/blob/potato/test/Potato/Reflex/Vty/Widget/LayoutSpec.hs) as it depends on [reflex-vty-test-host](https://github.com/pdlla/reflex-vty-test-host) which has not been merged yet.

Unfortunately the reflex frp network is a little convoluted. I think it pretty much has to be this way if we want to use the existing Layout monad design.

This PR is feature complete and has been tested.


## ~~Things left todo before PR is ready to be merged~~
- ~~improve documentation, possible add diagram showing how events are processed.~~
- ~~finish implementing and test "no focus" cases~~
- ~~finish implementing LayoutDebugTree~~
- ~~write test cases using https://github.com/pdlla/reflex-vty-test-host~~
- ~~update example code to use new Layout stuff~~