### PR TITLE
fix minor bug in zipper where cursor y position was computed incorrectly

### DIFF
--- a/src/Data/Text/Zipper.hs
+++ b/src/Data/Text/Zipper.hs
@@ -264,7 +264,7 @@ displayLines width tag cursorTag (TextZipper lb b a la) =
         , _displayLines_cursorY = sum
           [ length spansBefore
           , length spansCurrentBefore
-          , if cursorAfterEOL then cursorCharWidth else 0
+          , if cursorAfterEOL then 1 else 0
           ]
         }
   where


### PR DESCRIPTION
Previously `cursorCharWidth` was added to `_displayLines_cursorY` if the cursor was after EOL. I'm pretty sure this was meant to be a 1 as characters do not span more than 1 vertical cell 😮 

BTW, are folks OK with HUnit as a testing framework? I have a much bigger PR for TextZipper in the works that adds text alignment and new lines based on words rather than characters... And I want to add tests for it.