### PR TITLE
Add alignment support to TextZipper

### DIFF
--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -46,8 +46,7 @@ library
     ref-tf >= 0.4.0 && < 0.5,
     reflex >= 0.7.2 && < 0.8,
     time >= 1.8.0 && < 1.10,
-    vty >= 5.28 && < 5.29,
-    extra >= 1.7 && < 1.8
+    vty >= 5.28 && < 5.29
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -73,7 +73,7 @@ test-suite reflex-vty-test
   type: exitcode-stdio-1.0
   ghc-options: -threaded
   other-modules:
-    Data.Text.Zipper
+    Data.Text.ZipperSpec
   build-depends:
     base,
     reflex,

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -46,7 +46,8 @@ library
     ref-tf >= 0.4.0 && < 0.5,
     reflex >= 0.7.2 && < 0.8,
     time >= 1.8.0 && < 1.10,
-    vty >= 5.28 && < 5.29
+    vty >= 5.28 && < 5.29,
+    extra >= 1.7 && < 1.8
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall
@@ -64,6 +65,23 @@ executable example
     time,
     transformers,
     vty
+  default-language: Haskell2010
+
+test-suite reflex-vty-test
+  hs-source-dirs: test
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  ghc-options: -threaded
+  other-modules:
+    Data.Text.Zipper
+  build-depends:
+    base,
+    reflex,
+    containers,
+    reflex-vty,
+    text,
+    extra,
+    hspec >= 2.7 && < 2.8
   default-language: Haskell2010
 
 source-repository head

--- a/src/Data/Text/Zipper.hs
+++ b/src/Data/Text/Zipper.hs
@@ -156,7 +156,7 @@ deleteLeft z@(TextZipper lb b a la) = case T.unsnoc b of
 deleteRight :: TextZipper -> TextZipper
 deleteRight z@(TextZipper lb b a la) = case T.uncons a of
   Nothing -> case la of
-    []     -> z
+    [] -> z
     (l:ls) -> TextZipper lb b l ls
   Just (_, a') -> TextZipper lb b a' la
 
@@ -196,7 +196,7 @@ fromText = flip insert empty
 -- | A span of text tagged with some metadata that makes up part of a display
 -- line.
 data Span tag = Span tag Text
-    deriving (Show)
+  deriving (Show)
 
 -- | Information about the document as it is displayed (i.e., post-wrapping)
 data DisplayLines tag = DisplayLines

--- a/src/Data/Text/Zipper.hs
+++ b/src/Data/Text/Zipper.hs
@@ -269,7 +269,7 @@ displayLines width tag cursorTag (TextZipper lb b a la) =
         , _displayLines_cursorY = sum
           [ length spansBefore
           , length spansCurrentBefore
-          , if cursorAfterEOL then cursorCharWidth else 0
+          , if cursorAfterEOL then 1 else 0
           ]
         }
   where

--- a/src/Data/Text/Zipper.hs
+++ b/src/Data/Text/Zipper.hs
@@ -513,8 +513,8 @@ wrapWithOffsetAndAlignment
   -> Text -- ^ Text to be wrapped
   -> [(Text,Bool,Int)] -- (words on that line, hidden space char, offset from beginning of line)
 wrapWithOffsetAndAlignment _ maxWidth _ _ | maxWidth <= 0 = []
-wrapWithOffsetAndAlignment alignment maxWidth n text = assert (n <= maxWidth) r where
-  r' = splitWordsAtDisplayWidth maxWidth $ T.replicate n " " : wordsWithWhitespace text
+wrapWithOffsetAndAlignment alignment maxWidth n txt = assert (n <= maxWidth) r where
+  r' = splitWordsAtDisplayWidth maxWidth $ T.replicate n " " : wordsWithWhitespace txt
   fmapfn (t,b) = case alignment of
     TextAlignment_Left   -> (t,b,0)
     TextAlignment_Right  -> (t,b,maxWidth-l)
@@ -527,7 +527,7 @@ wrapWithOffsetAndAlignment alignment maxWidth n text = assert (n <= maxWidth) r 
 
 -- converts deleted eol spaces into logical lines
 eolSpacesToLogicalLines :: [[(Text, Bool, Int)]] -> [[(Text, Int)]]
-eolSpacesToLogicalLines = fmap (fmap (\(a, b, c) -> (a,c))) . join . fmap (L.groupBy (\(_,b,_) _ -> not b))
+eolSpacesToLogicalLines = fmap (fmap (\(a, _, c) -> (a,c))) . join . fmap (L.groupBy (\(_,b,_) _ -> not b))
 
 offsetMapWithAlignmentInternal :: [[(Text, Bool, Int)]] -> OffsetMapWithAlignment
 offsetMapWithAlignmentInternal = offsetMapWithAlignment . eolSpacesToLogicalLines

--- a/test/Data/Text/ZipperSpec.hs
+++ b/test/Data/Text/ZipperSpec.hs
@@ -35,14 +35,14 @@ spec = do
       fmap fst (splitSentenceAtDisplayWidth 5 "1234   56") `shouldBe` ["1234 "," 56"]
       fmap fst (splitSentenceAtDisplayWidth 8 "1 2 3 4 5 6 7 8 9 1") `shouldBe` ["1 2 3 4","5 6 7 8", "9 1"]
     it "wrapWithOffsetAndAlignment" $ do
-      wrapWithOffsetAndAlignment TextAlignment_Left 5 0 someSentence `shouldBe` [("12345", True, 0), ("1234", True, 0), ("12", False, 0)]
-      wrapWithOffsetAndAlignment TextAlignment_Right 5 0 someSentence `shouldBe` [("12345", True, 0), ("1234", True, 1), ("12", False, 3)]
-      wrapWithOffsetAndAlignment TextAlignment_Center 5 0 someSentence `shouldBe` [("12345", True, 0), ("1234", True, 0), ("12", False, 1)]
+      wrapWithOffsetAndAlignment TextAlignment_Left 5 0 someSentence `shouldBe` [(WrappedLine "12345" True 0), (WrappedLine "1234" True 0), (WrappedLine "12" False 0)]
+      wrapWithOffsetAndAlignment TextAlignment_Right 5 0 someSentence `shouldBe` [(WrappedLine "12345" True 0), (WrappedLine "1234" True 1), (WrappedLine "12" False 3)]
+      wrapWithOffsetAndAlignment TextAlignment_Center 5 0 someSentence `shouldBe` [(WrappedLine "12345" True 0), (WrappedLine "1234" True 0), (WrappedLine "12" False 1)]
     it "eolSpacesToLogicalLines" $ do
       eolSpacesToLogicalLines
         [
-          [ ("😱",True,1), ("😱",False,2), ("😱",False,3) ]
-          , [ ("aa",True,1), ("aa",True,2), ("aa",False,3) ]
+          [ (WrappedLine "😱" True 1), (WrappedLine "😱" False 2), (WrappedLine "😱" False 3) ]
+          , [ (WrappedLine "aa" True 1), (WrappedLine "aa" True 2), (WrappedLine "aa" False 3) ]
         ]
         `shouldBe`
         [
@@ -55,8 +55,8 @@ spec = do
     it "offsetMapWithAlignmentInternal" $ do
       offsetMapWithAlignmentInternal
         [
-          [ ("😱",True,1), ("😱",False,2), ("😱",False,3) ]
-          , [ ("aa",True,1), ("aa",True,2), ("aa",False,3) ]
+          [ (WrappedLine "😱" True 1), (WrappedLine "😱" False 2), (WrappedLine "😱" False 3) ]
+          , [ (WrappedLine "aa" True 1), (WrappedLine "aa" True 2), (WrappedLine "aa" False 3) ]
         ]
         `shouldBe`
         Map.fromList

--- a/test/Data/Text/ZipperSpec.hs
+++ b/test/Data/Text/ZipperSpec.hs
@@ -1,0 +1,96 @@
+--{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.Text.ZipperSpec(
+  spec
+) where
+
+import           Prelude
+
+import           Test.Hspec
+
+import Data.Text
+import qualified Data.Map            as Map
+
+import Data.Text.Zipper
+
+
+someSentence = "12345 1234 12"
+
+splitSentenceAtDisplayWidth :: Int -> Text -> [(Text, Bool)]
+splitSentenceAtDisplayWidth w t = splitWordsAtDisplayWidth w (wordsWithWhitespace t)
+
+spec :: Spec
+spec = do
+  describe "Zipper" $ do
+    it "wordsWithWhitespace" $ do
+      wordsWithWhitespace "" `shouldBe` []
+      wordsWithWhitespace "😱😱😱" `shouldBe` ["😱😱😱"]
+      wordsWithWhitespace "abcd efgf f" `shouldBe` ["abcd ","efgf ", "f"]
+      wordsWithWhitespace "aoeu    " `shouldBe` ["aoeu    "]
+    it "splitWordsAtDisplayWidth" $ do
+      fmap fst (splitSentenceAtDisplayWidth 5 "123456") `shouldBe` ["12345","6"]
+      fmap fst (splitSentenceAtDisplayWidth 5 "12345 6") `shouldBe` ["12345","6"]
+      fmap fst (splitSentenceAtDisplayWidth 5 "1234 56") `shouldBe` ["1234","56"]
+      fmap fst (splitSentenceAtDisplayWidth 5 "12345678912345") `shouldBe` ["12345","67891","2345"]
+      fmap fst (splitSentenceAtDisplayWidth 5 "1234   56") `shouldBe` ["1234 "," 56"]
+      fmap fst (splitSentenceAtDisplayWidth 8 "1 2 3 4 5 6 7 8 9 1") `shouldBe` ["1 2 3 4","5 6 7 8", "9 1"]
+    it "wrapWithOffsetAndAlignment" $ do
+      wrapWithOffsetAndAlignment TextAlignment_Left 5 0 someSentence `shouldBe` [("12345", True, 0), ("1234", True, 0), ("12", False, 0)]
+      wrapWithOffsetAndAlignment TextAlignment_Right 5 0 someSentence `shouldBe` [("12345", True, 0), ("1234", True, 1), ("12", False, 3)]
+      wrapWithOffsetAndAlignment TextAlignment_Center 5 0 someSentence `shouldBe` [("12345", True, 0), ("1234", True, 0), ("12", False, 1)]
+    it "eolSpacesToLogicalLines" $ do
+      eolSpacesToLogicalLines
+        [
+          [ ("😱",True,1), ("😱",False,2), ("😱",False,3) ]
+          , [ ("aa",True,1), ("aa",True,2), ("aa",False,3) ]
+        ]
+        `shouldBe`
+        [
+          [ ("😱",1) ]
+          , [ ("😱",2), ("😱",3) ]
+          , [ ("aa",1) ]
+          , [ ("aa",2) ]
+          , [ ("aa",3) ]
+        ]
+    it "offsetMapWithAlignmentInternal" $ do
+      offsetMapWithAlignmentInternal
+        [
+          [ ("😱",True,1), ("😱",False,2), ("😱",False,3) ]
+          , [ ("aa",True,1), ("aa",True,2), ("aa",False,3) ]
+        ]
+        `shouldBe`
+        Map.fromList
+        [ (0, (1,0))
+        , (1, (2,2)) -- jump by 1 for char and 1 for space
+        , (2, (3,3)) -- jump by 1 for char
+        , (3, (1,5)) -- jump by 1 for char and 1 for newline
+        , (4, (2,8)) -- jump by 2 for char and 1 for space
+        , (5, (3,11)) -- jump by 2 for char and 1 for space
+        ]
+    --it "displayLinesWithAlignment - empty" $ do
+      --let
+      --  dl = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "")
+      -- fails, produces [Span () "", Span () " "] because it creates an space character to for the cursor
+      --_displayLinesWithAlignment_spans dl `shouldBe` [Span () "", Span () ""]
+    it "displayLinesWithAlignment - cursorPos" $ do
+      let
+        dl0 = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "")
+        dl1 = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "aoeu")
+        dl2 = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "aoeu\n")
+        dl3 = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "0123456789")
+        dl4 = displayLinesWithAlignment TextAlignment_Right 10 () () (insertChar 'a' $ fromText "aoeu")
+        dl5 = displayLinesWithAlignment TextAlignment_Right 10 () () (left $ insertChar 'a' $ fromText "aoeu")
+        dl6 = displayLinesWithAlignment TextAlignment_Right 10 () () (deleteLeft $ insertChar 'a' $ fromText "aoeu")
+      _displayLinesWithAlignment_cursorPos dl0 `shouldBe` (0,0)
+      _displayLinesWithAlignment_cursorPos dl1 `shouldBe` (4,0)
+      _displayLinesWithAlignment_cursorPos dl2 `shouldBe` (0,1)
+      _displayLinesWithAlignment_cursorPos dl3 `shouldBe` (0,1)
+      _displayLinesWithAlignment_cursorPos dl4 `shouldBe` (5,0)
+      _displayLinesWithAlignment_cursorPos dl5 `shouldBe` (4,0)
+      _displayLinesWithAlignment_cursorPos dl6 `shouldBe` (4,0)
+    --it "displayLinesWithAlignment" $ do
+      --let
+        --dl = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "aoeu ansthe\naoeuo\naone , aoentuh ao anhno ao ao ou unh sarc.,as eohaun oeuoeu nthoeu noeuhnooeu")
+        --dl = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "")
+      --traceShow (_displayLinesWithAlignment_spans dl) (True `shouldBe` True)

--- a/test/Data/Text/ZipperSpec.hs
+++ b/test/Data/Text/ZipperSpec.hs
@@ -1,4 +1,3 @@
---{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.Text.ZipperSpec(
@@ -9,10 +8,10 @@ import           Prelude
 
 import           Test.Hspec
 
-import Data.Text
-import qualified Data.Map            as Map
+import qualified Data.Map         as Map
+import           Data.Text
 
-import Data.Text.Zipper
+import           Data.Text.Zipper
 
 
 someSentence = "12345 1234 12"
@@ -68,11 +67,6 @@ spec = do
         , (4, (2,8)) -- jump by 2 for char and 1 for space
         , (5, (3,11)) -- jump by 2 for char and 1 for space
         ]
-    --it "displayLinesWithAlignment - empty" $ do
-      --let
-      --  dl = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "")
-      -- fails, produces [Span () "", Span () " "] because it creates an space character to for the cursor
-      --_displayLinesWithAlignment_spans dl `shouldBe` [Span () "", Span () ""]
     it "displayLinesWithAlignment - cursorPos" $ do
       let
         dl0 = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "")
@@ -89,8 +83,3 @@ spec = do
       _displayLinesWithAlignment_cursorPos dl4 `shouldBe` (5,0)
       _displayLinesWithAlignment_cursorPos dl5 `shouldBe` (4,0)
       _displayLinesWithAlignment_cursorPos dl6 `shouldBe` (4,0)
-    --it "displayLinesWithAlignment" $ do
-      --let
-        --dl = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "aoeu ansthe\naoeuo\naone , aoentuh ao anhno ao ao ou unh sarc.,as eohaun oeuoeu nthoeu noeuhnooeu")
-        --dl = displayLinesWithAlignment TextAlignment_Right 10 () () (fromText "")
-      --traceShow (_displayLinesWithAlignment_spans dl) (True `shouldBe` True)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,2 @@
+-- hspec auto-discovery stuff
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,15 @@
 -- hspec auto-discovery stuff
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+-- does not work with current CircleCI image so instead we do it manually for now
+-- {-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+
+
+import Test.Hspec
+
+import qualified Data.Text.ZipperSpec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Data.Text.ZipperSpec"     Data.Text.ZipperSpec.spec


### PR DESCRIPTION
-add alignment (left/center/right) support to TextZipper.
-add basic unit tests for newly created alignment methods in TextZipper
-also includes fix from https://github.com/reflex-frp/reflex-vty/pull/38