### PR TITLE
Refactor 'textInput' for more data flow patterns

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for reflex-vty
 
+## Unreleased
+
+* Re-design `textInput`, `TextInput` and `TextInputConfig`.
+  * Allows users to implement more complex behaviour.
+
 ## 0.2.0.1
 
 * Loosen version bounds on ref-tf and vty

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 * Re-design `textInput`, `TextInput` and `TextInputConfig`.
-  * Allows users to implement more complex behaviour.
+  * Allows users to implement more complex behavior.
+  * `_textInputConfig_modify` is now applied to the text-value of `textInput`
+    after user input events such as mouse clicks and keyboard input.
+    This may change the observable behavior.
 
 ## 0.2.0.1
 

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -56,7 +56,7 @@ library
     ref-tf >= 0.4.0 && < 0.6,
     reflex >= 0.8 && < 0.9,
     time >= 1.8.0 && < 1.10,
-    vty >= 5.28 && < 5.37
+    vty >= 5.28 && < 5.34
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/src/Reflex/Vty/Widget/Input/Text.hs
+++ b/src/Reflex/Vty/Widget/Input/Text.hs
@@ -45,7 +45,7 @@ data TextInputConfig t = TextInputConfig
   -- ^ Optionally set the value of the textInput field.
   --
   -- If set, this will override any Events sent by the UI,
-  -- events from '_testInput_updated' are no longer automatically applied
+  -- events from '_textInput_userInput' are no longer automatically applied
   -- to the textInput.
   , _textInputConfig_tabWidth :: Int
   , _textInputConfig_display :: Dynamic t (Char -> Char)
@@ -62,7 +62,7 @@ instance Reflex t => Default (TextInputConfig t) where
 data TextInput t = TextInput
   { _textInput_value :: Dynamic t Text
   -- ^ The current value of the textInput as Text.
-  , _testInput_updated :: Event t TextZipper
+  , _textInput_userInput :: Event t TextZipper
   -- ^ UI Event updates with the current 'TextZipper'.
   -- This does not include Events added by '_testInputConfig_setValue', but
   -- it does include '_textInputConfig_modify' Events.
@@ -123,7 +123,7 @@ textInput cfg = do
       tellImages $ (\imgs st -> (:[]) . V.vertCat $ drop st imgs) <$> current img <*> scrollTop
   return $ TextInput
     { _textInput_value = value <$> v
-    , _testInput_updated = attachWith (&) (current v) valueChangedByUI
+    , _textInput_userInput = attachWith (&) (current v) valueChangedByUI
     , _textInput_lines = length . _displayLines_spans <$> rows
     }
 

--- a/src/Reflex/Vty/Widget/Input/Text.hs
+++ b/src/Reflex/Vty/Widget/Input/Text.hs
@@ -84,7 +84,7 @@ textInput cfg = do
   rec
       -- we split up the events from vty and the one users provide to avoid cyclical
       -- update dependencies. This way, users may subscribe only to UI updates.
-      let valueChangedByUser = _textInputConfig_modify cfg
+      let valueChangedByCaller = _textInputConfig_modify cfg
       let valueChangedByUI = mergeWith (.)
             [ uncurry (updateTextZipper (_textInputConfig_tabWidth cfg)) <$> attach (current dh) i
             , let displayInfo = (,) <$> current rows <*> scrollTop
@@ -92,7 +92,7 @@ textInput cfg = do
                 goToDisplayLinePosition mx (st + my) dl
             ]
       v <- foldDyn ($) (_textInputConfig_initialValue cfg) $ mergeWith (.)
-        [ valueChangedByUser
+        [ valueChangedByCaller
         , valueChangedByUI
         ]
       click <- mouseDown V.BLeft

--- a/src/Reflex/Vty/Widget/Input/Text.hs
+++ b/src/Reflex/Vty/Widget/Input/Text.hs
@@ -41,7 +41,7 @@ data TextInputConfig t = TextInputConfig
   --         _ -> Nothing
   --     }
   -- @
-  , _testInputConfig_setValue :: Maybe (Event t TextZipper)
+  , _textInputConfig_setValue :: Maybe (Event t TextZipper)
   -- ^ Optionally set the value of the textInput field.
   --
   -- If set, this will override any Events sent by the UI,
@@ -64,7 +64,7 @@ data TextInput t = TextInput
   -- ^ The current value of the textInput as Text.
   , _textInput_userInput :: Event t TextZipper
   -- ^ UI Event updates with the current 'TextZipper'.
-  -- This does not include Events added by '_testInputConfig_setValue', but
+  -- This does not include Events added by '_textInputConfig_setValue', but
   -- it does include '_textInputConfig_modify' Events.
   , _textInput_lines :: Dynamic t Int
   }
@@ -84,7 +84,7 @@ textInput cfg = do
   rec
       -- we split up the events from vty and the one users provide to avoid cyclical
       -- update dependencies. This way, users may subscribe only to UI updates.
-      valueChangedBySetValue <- case _testInputConfig_setValue cfg of
+      valueChangedBySetValue <- case _textInputConfig_setValue cfg of
         Nothing -> pure never
         Just eSetValue -> pure $ fmap const eSetValue
       let valueChangedByUI = mergeWith (.)


### PR DESCRIPTION
Refactor 'TextInput' to allow a way to set the value of the textInput similar to how 'reflex-dom' does it:
https://hackage.haskell.org/package/reflex-dom-core-0.7.0.2/docs/Reflex-Dom-Builder-Class.html#t:InputElementConfig

Update Documentation for existing and newly added fields.

Also closes #56 