### PR TITLE
Fix several issues in Zipper.hs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for reflex-vty
 
+## Unreleased
+
+* Fix several issues with wide chars, cursor position and word wrapping in Zipper.hs
+
 ## 0.4.1.1
 
 * Support ghc-9.6
@@ -18,7 +22,7 @@
     * Mouse drag sequences that start ON the region and drag off ARE reported
     * Introduce `MonadHold` constraint to `pane`
   * Added `MonadHold` constraint to several methods that use `pane`
-  
+
 ## 0.3.1.1
 
 * Loosen version bounds and support GHC 9.4

--- a/src/Data/Text/Zipper.hs
+++ b/src/Data/Text/Zipper.hs
@@ -13,12 +13,12 @@ import           Prelude
 
 import Control.Exception (assert)
 import Control.Monad
-import Control.Monad.State (evalState, forM, get, put)
+import Control.Monad.State (evalState, get, put)
 import Data.Char (isSpace)
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.String
-import Control.Monad
+import Control.Monad (forM)
 import Control.Monad.Fix
 import Control.Monad.State (evalState, get, put)
 

--- a/src/Reflex/Vty/Widget.hs
+++ b/src/Reflex/Vty/Widget.hs
@@ -232,7 +232,7 @@ inputInFocusedRegion = do
       return $ case e of
         V.EvKey _ _ | not focused -> Nothing
         V.EvMouseDown x y btn m ->
-          if tracking == Tracking btn || (tracking == WaitingForInput && isWithin reg' x y)
+          if tracking == Tracking btn || (tracking == WaitingForInput && withinRegion reg' x y)
             then Just (Tracking btn, Just $ V.EvMouseDown (x - l) (y - t) btn m)
             else Just (NotTracking, Nothing)
         V.EvMouseUp x y mbtn -> case mbtn of
@@ -268,11 +268,20 @@ nilRegion = Region 0 0 0 0
 regionSize :: Region -> (Int, Int)
 regionSize (Region _ _ w h) = (w, h)
 
-isWithin :: Region -> Int -> Int -> Bool
-isWithin (Region l t w h) x y = not . or $ [ x < l
-                                           , y < t
-                                           , x >= l + w
-                                           , y >= t + h ]
+-- | Check whether the x,y coordinates are within the specified region
+withinRegion
+  :: Region
+  -> Int
+  -- ^ x-coordinate
+  -> Int
+  -- ^ y-coordinate
+  -> Bool
+withinRegion (Region l t w h) x y = not . or $
+  [ x < l
+  , y < t
+  , x >= l + w
+  , y >= t + h
+  ]
 
 -- | Produces an 'Image' that fills a region with space characters
 regionBlankImage :: V.Attr -> Region -> Image

--- a/src/Reflex/Vty/Widget/Layout.hs
+++ b/src/Reflex/Vty/Widget/Layout.hs
@@ -9,7 +9,6 @@ module Reflex.Vty.Widget.Layout where
 import Control.Applicative (liftA2)
 import Control.Monad.Morph
 import Control.Monad.NodeId (MonadNodeId(..), NodeId)
-import Control.Monad
 import Control.Monad.Fix
 import Control.Monad.Reader
 import Data.List (mapAccumL)

--- a/test/Data/Text/ZipperSpec.hs
+++ b/test/Data/Text/ZipperSpec.hs
@@ -14,8 +14,6 @@ import Control.Monad
 
 import           Data.Text.Zipper
 
-import Debug.Trace
-
 someSentence :: T.Text
 someSentence = "12345 1234 12"
 


### PR DESCRIPTION
This PR fixes several bugs in Zipper.hs

- fix wide char indexing issues due to issues in `toLogicalIndex`
- rewrite part of `displayLinesWithAlignment` to simplify and address cursor position issue as well as some other issues