### PR TITLE
Expand cabal package bounds for hspec and primitive

### DIFF
--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -54,7 +54,7 @@ library
     exception-transformers >= 0.4.0 && < 0.5,
     mmorph >= 1.1 && < 1.3,
     ordered-containers >= 0.2.2 && < 0.3,
-    primitive >= 0.6.3 && < 0.8,
+    primitive >= 0.6.3 && < 0.9,
     ref-tf >= 0.4.0 && < 0.6,
     reflex >= 0.9.2 && < 1,
     time >= 1.8.0 && < 1.13,

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -154,5 +154,5 @@ test-suite reflex-vty-test
     reflex-vty,
     text,
     extra,
-    hspec >= 2.7 && < 2.11
+    hspec >= 2.7 && < 2.12
   default-language: Haskell2010


### PR DESCRIPTION
Reflex-vty builds fine with newer versions of hspec and primitive. I tested `reflex-ghci` and it seems to work as well.

If you could add a cabal file revision for 0.5.2.0 on Hackage, that would help as well, thanks.

Changelogs:
- [hspec-2.11](https://hackage.haskell.org/package/hspec-2.11.7/changelog#changes-in-2110-2023-04-21)
- [primitive-0.8.0.0](https://hackage.haskell.org/package/primitive-0.9.0.0/changelog#changes-in-version-0800)

Stackage LTS 22 versions:
 - [hspec-2.11.7](https://www.stackage.org/lts-22.12/package/hspec-2.11.7)
 - [primitive-0.8.0.0](https://www.stackage.org/lts-22.12/package/primitive-0.8.0.0)
