### PR TITLE
cabal: Allow vty 6.2

### DIFF
--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -58,7 +58,7 @@ library
     ref-tf >= 0.4.0 && < 0.6,
     reflex >= 0.9.2 && < 1,
     time >= 1.8.0 && < 1.13,
-    vty >= 6.0 && < 6.2,
+    vty >= 6.0 && < 6.3,
     vty-crossplatform >= 0.1 && < 0.5
   hs-source-dirs: src
   default-language: Haskell2010

--- a/release.nix
+++ b/release.nix
@@ -9,8 +9,8 @@ let
   commonOverrides = self: super: {
     vty = self.callHackageDirect {
       pkg = "vty";
-      ver = "6.1";
-      sha256 = "2cefcb5764f6b662440ba9e56c30282da37071b599a7def7fc8e5679f2602bf8";
+      ver = "6.2";
+      sha256 = "sha256-7NePMONSoKJ/DQa4FSsFBy8ScGwWHU0nL7DomJCh+9Y=";
     } {};
     vty-crossplatform = self.callHackageDirect {
       pkg = "vty-crossplatform";


### PR DESCRIPTION
Increases package bounds to allow [vty-6.2](https://hackage.haskell.org/package/vty-6.2/changelog).

The only issue I found while testing was that the text editor example is unreadable on my screen (gnome-terminal with gnome dark theme and "use colours from system theme" enabled).

The following change did fix it though (for both light and dark colour schemes):

```patch
diff --git a/src-bin/example.hs b/src-bin/example.hs
index 9a2a2ea..61e576d 100644
--- a/src-bin/example.hs
+++ b/src-bin/example.hs
@@ -55,7 +55,7 @@ darkTheme :: V.Attr
 darkTheme = V.Attr {
   V.attrStyle = V.SetTo V.standout
   , V.attrForeColor = V.SetTo V.black
-  , V.attrBackColor = V.Default
+  , V.attrBackColor = V.SetTo V.white
   , V.attrURL = V.Default
 }
```