### PR TITLE
scrollable: promptly use `displayHight` on scroll

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for reflex-vty
 
+## 0.6.1.1
+
+* Extend version bounds
+* Add support for GHC 9.8.4
+
 ## 0.6.1.0
 
 * Fix mouse input translation in scrollable elements

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -1,5 +1,5 @@
 name: reflex-vty
-version: 0.6.1.0
+version: 0.6.1.1
 synopsis: Reflex FRP host and widgets for VTY applications
 description:
   Build terminal applications using functional reactive programming (FRP) with Reflex FRP (<https://reflex-frp.org>).

--- a/src/Reflex/Vty/Widget/Scroll.hs
+++ b/src/Reflex/Vty/Widget/Scroll.hs
@@ -72,12 +72,12 @@ scrollable (ScrollableConfig scrollBy scrollTo startingPos onAppend) mkImg = do
     ((update, a), imgs) <- captureImages $ localInput (translateMouseEvents translation) $ mkImg
     let sz = foldl' max 0 . fmap V.imageHeight <$> imgs
     lineIndex <- foldDynMaybe ($) startingPos $ leftmost
-      [ (\((totalLines, h), d) sp -> Just $ scrollByLines sp totalLines h d) <$> attach ((,) <$> sz <*> current dh) requestedScroll
-      , (\((totalLines, h), newScrollPosition) _ -> Just $ case newScrollPosition of
+      [ (\(totalLines, (h, d)) sp -> Just $ scrollByLines sp totalLines h d) <$> attach sz (attachPromptlyDyn dh requestedScroll)
+      , (\(totalLines, (h, newScrollPosition)) _ -> Just $ case newScrollPosition of
           ScrollPos_Line n -> scrollToLine totalLines h n
           ScrollPos_Top -> ScrollPos_Top
           ScrollPos_Bottom -> ScrollPos_Bottom
-        ) <$> attach ((,) <$> sz <*> current dh) scrollTo
+        ) <$> attach sz (attachPromptlyDyn dh scrollTo)
       , (\cfg sp -> case cfg of
           Just ScrollToBottom_Always -> case sp of
             ScrollPos_Bottom -> Nothing


### PR DESCRIPTION
During a scroll event, use the updated `displayheight` over the current `displayHight` when calculating the new `scrollPosition`.

Fix #93