### PR TITLE
Relax bounds for GHC 9.12.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.10.7', '9.4.5', '9.6.1', '9.8.4']
+        ghc: ['8.10.7', '9.4.5', '9.6.1', '9.8.4', '9.10.1', '9.12.2' ]
         os: ['ubuntu-latest', 'macos-13'] # https://github.com/haskell-actions/setup/issues/77
     runs-on: ${{ matrix.os }}
 

--- a/reflex-vty.cabal
+++ b/reflex-vty.cabal
@@ -18,7 +18,7 @@ extra-source-files:
   ChangeLog.md
 extra-doc-files: doc/tasks.png
 tested-with:
-  GHC ==8.10.7 || ==9.4.5 || ==9.6.1 || ==9.8.4
+  GHC ==8.10.7 || ==9.4.5 || ==9.6.1 || ==9.8.4 || ==9.10.1 || == 9.12.2
 
 source-repository head
   type: git
@@ -40,9 +40,9 @@ library
                  , Reflex.Spider.Orphans
                  , Control.Monad.NodeId
   build-depends:
-    base >= 4.10.0 && < 4.20,
+    base >= 4.10.0 && < 4.22,
     bimap >= 0.3.3 && < 0.6,
-    containers >= 0.5.0 && < 0.7,
+    containers >= 0.5.0 && < 0.8,
     mtl >= 2.2.2 && < 2.4,
     transformers >= 0.5.5 && < 0.7,
     stm >= 2.4 && < 2.6,
@@ -57,7 +57,7 @@ library
     primitive >= 0.6.3 && < 0.10,
     ref-tf >= 0.4.0 && < 0.6,
     reflex >= 0.9.2 && < 1,
-    time >= 1.8.0 && < 1.13,
+    time >= 1.8.0 && < 1.15,
     vty >= 6.0 && < 6.3,
     vty-crossplatform >= 0.1 && < 0.5
   hs-source-dirs: src


### PR DESCRIPTION
Built with `ghc9122` and `ghc9101` against nixpkgs [`25e53aa156d4`](https://github.com/NixOS/nixpkgs/commit/25e53aa156d47bad5082ff7618f5feb1f5e02d01) (which is just what my system was pointing to…) + tested all the widgets in the example app on both versions.